### PR TITLE
Fix missing upscale results

### DIFF
--- a/pkg/ai/midjourney/midjourney.go
+++ b/pkg/ai/midjourney/midjourney.go
@@ -362,9 +362,9 @@ func (c *Client) Imagine(ctx context.Context, prompt string) (*ai.Preview, error
 	c.debugLog("IMAGINE", imagine)
 
 	response, err := c.receiveMessage(ctx, nonceSearch(nonce), func() error {
-		// Launch imagine interaction inside the receive message process
-		// because the response may be received before it finishes, due to
-		// rate limit locking.
+		// Launch interaction inside the receive message process because the
+		// response may be received before it finishes, due to rate limit
+		// locking.
 		if _, err := c.c.Do(ctx, "POST", "interactions", imagine); err != nil {
 			return fmt.Errorf("midjourney: couldn't send imagine interaction: %w", err)
 		}
@@ -432,11 +432,16 @@ func (c *Client) Upscale(ctx context.Context, preview *ai.Preview, index int) (s
 		MessageID: preview.MessageID,
 	}
 	c.debugLog("UPSCALE", upscale)
-	if _, err := c.c.Do(ctx, "POST", "interactions", upscale); err != nil {
-		return "", fmt.Errorf("midjourney: couldn't send upscale interaction: %w", err)
-	}
 
-	msg, err := c.receiveMessage(ctx, upscaleSearch(preview.ResponsePrompt), nil)
+	msg, err := c.receiveMessage(ctx, upscaleSearch(preview.ResponsePrompt), func() error {
+		// Launch interaction inside the receive message process because the
+		// response may be received before it finishes, due to rate limit
+		// locking.
+		if _, err := c.c.Do(ctx, "POST", "interactions", upscale); err != nil {
+			return fmt.Errorf("midjourney: couldn't send upscale interaction: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return "", fmt.Errorf("midjourney: couldn't receive links message: %w", err)
 	}
@@ -463,11 +468,16 @@ func (c *Client) Variation(ctx context.Context, preview *ai.Preview, index int) 
 		MessageID: preview.MessageID,
 	}
 	c.debugLog("VARIATION", variation)
-	if _, err := c.c.Do(ctx, "POST", "interactions", variation); err != nil {
-		return nil, fmt.Errorf("midjourney: couldn't send variation interaction: %w", err)
-	}
 
-	msg, err := c.receiveMessage(ctx, variationSearch(preview.ResponsePrompt), nil)
+	msg, err := c.receiveMessage(ctx, variationSearch(preview.ResponsePrompt), func() error {
+		// Launch interaction inside the receive message process because the
+		// response may be received before it finishes, due to rate limit
+		// locking.
+		if _, err := c.c.Do(ctx, "POST", "interactions", variation); err != nil {
+			return fmt.Errorf("midjourney: couldn't send variation interaction: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("midjourney: couldn't receive links message: %w", err)
 	}


### PR DESCRIPTION
Every time a new interaction is sent, the method blocks for a while to
deal with rate limiting. This was causing that quick results were not
being captured because the receiver was being called to late.
Now all receivers are launched before the interaction is sent.

Closes #3
