### PR TITLE
Handle midjourney queue errors

### DIFF
--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -303,6 +303,16 @@ func retry(ctx context.Context, fn func(context.Context) error) error {
 		if attempts >= maxAttempts {
 			return err
 		}
-		log.Println("retrying...", err)
+		// If the error is not a context deadline exceeded, wait before retrying
+		if !errors.Is(err, context.DeadlineExceeded) {
+			log.Println("waiting and retrying...", err)
+			select {
+			case <-time.After(10 * time.Minute):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		} else {
+			log.Println("retrying...", err)
+		}
 	}
 }


### PR DESCRIPTION
When job queued error is received instead of returning an error the response is read from the embedded data of the message and the process continues.

When a non temporary error is received such as a "queue full" error the tool should wait before retrying to avoid flooding the queue.

References #14