### PR TITLE
Feature: HTML flag to decide whether to generate HTML files or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This will generate 4 extra variations of each prompt.
 The generation will be much slower.
  - `thumbnail` (bool): Generate thumbnails of the generated images. (default: `true`)
 This operation is done locally, it will improve the performance of the HTML page.
+ - `html` (bool): Generate HTML files to show and link the generated images. (default: `true`)
  - `suffix` (string): Suffix to add to all prompts. (optional)
  - `prefix` (string): Prefix to add to all prompts. (optional)
  - `prompt` (list): List of prompts to use. (required)

--- a/bulkai.go
+++ b/bulkai.go
@@ -55,6 +55,7 @@ type Config struct {
 	Upscale        bool          `yaml:"upscale"`
 	Download       bool          `yaml:"download"`
 	Thumbnail      bool          `yaml:"thumbnail"`
+	Html           bool          `yaml:"html"`
 	Channel        string        `yaml:"channel"`
 	Concurrency    int           `yaml:"concurrency"`
 	Wait           time.Duration `yaml:"wait"`
@@ -309,7 +310,7 @@ func Generate(ctx context.Context, cfg *Config, opts ...Option) error {
 				}
 			}
 		}
-		if err := SaveAlbum(albumDir, album, cfg.Thumbnail); err != nil {
+		if err := SaveAlbum(albumDir, album, cfg.Thumbnail, cfg.Html); err != nil {
 			return fmt.Errorf("couldn't save album: %w", err)
 		}
 		log.Println("album created:", albumDir)
@@ -363,7 +364,7 @@ func Generate(ctx context.Context, cfg *Config, opts ...Option) error {
 		album.Percentage = percentage
 		album.Status = status
 
-		err := SaveAlbum(albumDir, album, cfg.Thumbnail)
+		err := SaveAlbum(albumDir, album, cfg.Thumbnail, cfg.Html)
 		lck.Unlock()
 		if err != nil {
 			return fmt.Errorf("couldn't generate html: %w", err)
@@ -495,7 +496,7 @@ type htmlImage struct {
 	Prompt string
 }
 
-func SaveAlbum(dir string, a *Album, thumbnail bool) error {
+func SaveAlbum(dir string, a *Album, thumbnail bool, html bool) error {
 	// Sort images
 	images := a.Images
 	sort.Slice(images, func(i, j int) bool {
@@ -509,6 +510,11 @@ func SaveAlbum(dir string, a *Album, thumbnail bool) error {
 	}
 	if err := os.WriteFile(fmt.Sprintf("%s/data.json", dir), js, 0644); err != nil {
 		return fmt.Errorf("couldn't write album: %w", err)
+	}
+
+	// Skip to generate html files
+	if !html {
+		return nil
 	}
 
 	var local htmlData

--- a/cmd/bulkai/main.go
+++ b/cmd/bulkai/main.go
@@ -68,6 +68,7 @@ func newGenerateCommand() *ffcli.Command {
 	fs.BoolVar(&cfg.Download, "download", true, "download images")
 	fs.BoolVar(&cfg.Upscale, "upscale", true, "upscale images")
 	fs.BoolVar(&cfg.Thumbnail, "thumbnail", true, "generate thumbnails")
+	fs.BoolVar(&cfg.Html, "html", true, "generate html files")
 	fs.StringVar(&cfg.Channel, "channel", "", "channel in format guid/channel (optional, if not provided DMs will be used)")
 	fs.IntVar(&cfg.Concurrency, "concurrency", 0, "concurrency (optional, if not provided the maximum for the bot will be used)")
 	fs.DurationVar(&cfg.Wait, "wait", 0, "wait time between prompts (optional)")


### PR DESCRIPTION
This feature provides `html` flag (default is true, which means doing generate) in your configuration to toggle the generating process.

Almost all people still need those generated HTML files to confirm all images on a browser easily.
However, others like me do not need such extra files, only final images.
Bulkai is an awesome tool that enables quick access to Midjourney and is easy for me.
This patch lets the tool move closer to my purpose, and I hope this is for others with the same purpose.

bulkai.yaml
```yaml
bot: midjourney
album: cute-animals
download: true
upscale: true
variation: false
thumbnail: false
html: false
suffix: " --ar 3:2"
prompt:
  - cute-animals-1.txt
  - cute-animals-2.txt
  - cute monkey dancing on a tree
```