### PR TITLE
Add Midjourney CDN for URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If unset the DM chat with the bot will be used.
 If unset the maximum for the bot will be used.
  - `wait` (duration): Time to wait between prompts, for example `5s`. (optional)
 There is already a rate limit implemented to avoid sending too many requests to discord.
+ - `discord-cdn` (bool): Use Discord CDN for URLs instead of Midjourney CDN URLs. (default: `false`)
  - `debug` (bool): Enable debug mode. (default: `false`)
 
 ## FAQ

--- a/bulkai.go
+++ b/bulkai.go
@@ -60,6 +60,7 @@ type Config struct {
 	Concurrency    int           `yaml:"concurrency"`
 	Wait           time.Duration `yaml:"wait"`
 	ReplicateToken string        `yaml:"replicate-token"`
+	DiscordCDN     bool          `yaml:"discord-cdn"`
 	SessionFile    string        `yaml:"session"`
 	Session        Session       `yaml:"-"`
 }
@@ -138,6 +139,7 @@ func Generate(ctx context.Context, cfg *Config, opts ...Option) error {
 				ChannelID:      channelID,
 				Debug:          debug,
 				ReplicateToken: cfg.ReplicateToken,
+				DiscordCDN:     cfg.DiscordCDN,
 			})
 		}
 	default:

--- a/cmd/bulkai/main.go
+++ b/cmd/bulkai/main.go
@@ -74,6 +74,7 @@ func newGenerateCommand() *ffcli.Command {
 	fs.DurationVar(&cfg.Wait, "wait", 0, "wait time between prompts (optional)")
 	fs.BoolVar(&cfg.Debug, "debug", false, "debug mode")
 	fs.StringVar(&cfg.ReplicateToken, "replicate-token", "", "replicate token (optional)")
+	fs.BoolVar(&cfg.DiscordCDN, "discord-cdn", false, "use discord cdn instead of midjourney cdn")
 
 	// Session
 	fs.StringVar(&cfg.SessionFile, "session", "session.yaml", "session config file (optional)")


### PR DESCRIPTION
This change uses "cdn.midjourney.com" for upscaled image URLs instead of discord CDN URLs. Discord URLs expire after a while and are not reliable for long-term use.

A flag `discord-cdn` has been added for those who still want to use discord CDN URLs.