### PR TITLE
Default to use discord CDN URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If unset the DM chat with the bot will be used.
 If unset the maximum for the bot will be used.
  - `wait` (duration): Time to wait between prompts, for example `5s`. (optional)
 There is already a rate limit implemented to avoid sending too many requests to discord.
- - `discord-cdn` (bool): Use Discord CDN for URLs instead of Midjourney CDN URLs. (default: `false`)
+ - `midjourney-cdn` (bool): Use Midjourney CDN for URLs instead of Discord CDN URLs. (default: `false`)
  - `debug` (bool): Enable debug mode. (default: `false`)
 
 ## ❓ FAQ

--- a/bulkai.go
+++ b/bulkai.go
@@ -60,7 +60,7 @@ type Config struct {
 	Concurrency    int           `yaml:"concurrency"`
 	Wait           time.Duration `yaml:"wait"`
 	ReplicateToken string        `yaml:"replicate-token"`
-	DiscordCDN     bool          `yaml:"discord-cdn"`
+	MidjourneyCDN  bool          `yaml:"midjourney-cdn"`
 	SessionFile    string        `yaml:"session"`
 	Session        Session       `yaml:"-"`
 }
@@ -139,7 +139,7 @@ func Generate(ctx context.Context, cfg *Config, opts ...Option) error {
 				ChannelID:      channelID,
 				Debug:          debug,
 				ReplicateToken: cfg.ReplicateToken,
-				DiscordCDN:     cfg.DiscordCDN,
+				MidjourneyCDN:  cfg.MidjourneyCDN,
 			})
 		}
 	default:

--- a/cmd/bulkai/main.go
+++ b/cmd/bulkai/main.go
@@ -74,7 +74,7 @@ func newGenerateCommand() *ffcli.Command {
 	fs.DurationVar(&cfg.Wait, "wait", 0, "wait time between prompts (optional)")
 	fs.BoolVar(&cfg.Debug, "debug", false, "debug mode")
 	fs.StringVar(&cfg.ReplicateToken, "replicate-token", "", "replicate token (optional)")
-	fs.BoolVar(&cfg.DiscordCDN, "discord-cdn", false, "use discord cdn instead of midjourney cdn")
+	fs.BoolVar(&cfg.MidjourneyCDN, "midjourney-cdn", false, "use midjourney cdn instead of discord cdn")
 
 	// Session
 	fs.StringVar(&cfg.SessionFile, "session", "session.yaml", "session config file (optional)")

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -25,7 +25,7 @@ type Preview struct {
 type Client interface {
 	Start(ctx context.Context) error
 	Imagine(ctx context.Context, prompt string) (*Preview, error)
-	Upscale(ctx context.Context, preview *Preview, index int) (string, error)
+	Upscale(ctx context.Context, preview *Preview, index int) ([]string, error)
 	Variation(ctx context.Context, preview *Preview, index int) (*Preview, error)
 	Concurrency() int
 }
@@ -274,7 +274,7 @@ func upscale(cli Client, ctx context.Context, preview *Preview, index int) (stri
 		if err != nil {
 			return err
 		}
-		upscaleURL = u
+		upscaleURL = u[0]
 		return nil
 	}); err != nil {
 		return "", err

--- a/pkg/ai/bluewillow/bluewillow.go
+++ b/pkg/ai/bluewillow/bluewillow.go
@@ -414,9 +414,9 @@ func (c *Client) Imagine(ctx context.Context, prompt string) (*ai.Preview, error
 	}, nil
 }
 
-func (c *Client) Upscale(ctx context.Context, preview *ai.Preview, index int) (string, error) {
+func (c *Client) Upscale(ctx context.Context, preview *ai.Preview, index int) ([]string, error) {
 	if index < 0 || index >= len(preview.ImageIDs) {
-		return "", fmt.Errorf("bluewillow: invalid index %d", index)
+		return nil, fmt.Errorf("bluewillow: invalid index %d", index)
 	}
 	customID := fmt.Sprintf("%s%s", upscaleID, preview.ImageIDs[index])
 	nonce := c.node.Generate().String()
@@ -445,9 +445,9 @@ func (c *Client) Upscale(ctx context.Context, preview *ai.Preview, index int) (s
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("bluewillow: couldn't receive links message: %w", err)
+		return nil, fmt.Errorf("bluewillow: couldn't receive links message: %w", err)
 	}
-	return msg.Attachments[0].URL, nil
+	return []string{msg.Attachments[0].URL}, nil
 }
 
 func (c *Client) Variation(ctx context.Context, preview *ai.Preview, index int) (*ai.Preview, error) {


### PR DESCRIPTION
Most of the time, the temporary Discord URLs are enough to download
the images, so we can default to using them.
An optional parameter `midjourney-cdn` has been added to use the
Midjourney CDN instead.
